### PR TITLE
arki55/features/T10-github-builds-no-gzip-final  ==>  master

### DIFF
--- a/libspectrum.c
+++ b/libspectrum.c
@@ -840,10 +840,10 @@ libspectrum_uncompress_file( unsigned char **new_buffer, size_t *new_length,
 
 #else				/* #ifdef HAVE_ZLIB_H */
 
-    libspectrum_print_error( LIBSPECTRUM_ERROR_UNKNOWN,
+    libspectrum_print_error( LIBSPECTRUM_ERROR_MISSING_ZLIB,
 			     "zlib not available to decompress gzipped file" );
     if( new_filename ) libspectrum_free( *new_filename );
-    return LIBSPECTRUM_ERROR_UNKNOWN;
+    return LIBSPECTRUM_ERROR_MISSING_ZLIB;
 
 #endif				/* #ifdef HAVE_ZLIB_H */
 

--- a/libspectrum.h.in
+++ b/libspectrum.h.in
@@ -99,6 +99,7 @@ typedef enum libspectrum_error {
   LIBSPECTRUM_ERROR_SIGNATURE,
   LIBSPECTRUM_ERROR_SLT,	/* .slt data found at end of a .z80 file */
   LIBSPECTRUM_ERROR_INVALID,	/* Invalid parameter supplied */
+  LIBSPECTRUM_ERROR_MISSING_ZLIB, /* Missing or not used zlib.h */
 
   LIBSPECTRUM_ERROR_LOGIC = -1,
 

--- a/test/test.c
+++ b/test/test.c
@@ -256,6 +256,10 @@ test_3( void )
 static test_return_t
 test_4( void )
 {
+  #ifndef HAVE_ZLIB_H
+    return TEST_SKIPPED; /* gzip not enabled in build */
+  #endif
+
   const char *filename = STATIC_TEST_PATH( "invalid.gz" );
   return read_snap( filename, filename, LIBSPECTRUM_ERROR_UNKNOWN );
 }
@@ -264,6 +268,10 @@ test_4( void )
 static test_return_t
 test_5( void )
 {
+  #ifndef HAVE_ZLIB_H
+    return TEST_SKIPPED; /* gzip not enabled in build */
+  #endif
+
   return read_snap( STATIC_TEST_PATH( "invalid.gz" ), NULL, LIBSPECTRUM_ERROR_UNKNOWN );
 }
 
@@ -413,6 +421,10 @@ test_19( void )
 static test_return_t
 test_20( void )
 {
+  #ifndef HAVE_ZLIB_H
+    return TEST_SKIPPED; /* gzip not enabled in build */
+  #endif
+
   const char *filename = STATIC_TEST_PATH( "sp-2000.sna.gz" );
   return read_snap( filename, filename, LIBSPECTRUM_ERROR_CORRUPT );
 } 
@@ -420,6 +432,10 @@ test_20( void )
 static test_return_t
 test_21( void )
 {
+  #ifndef HAVE_ZLIB_H
+    return TEST_SKIPPED; /* gzip not enabled in build */
+  #endif
+
   const char *filename = STATIC_TEST_PATH( "sp-ffff.sna.gz" );
   return read_snap( filename, filename, LIBSPECTRUM_ERROR_CORRUPT );
 } 
@@ -690,6 +706,10 @@ test_26( void )
 static test_return_t
 test_27( void )
 {
+  #ifndef HAVE_ZLIB_H
+    return TEST_SKIPPED; /* gzip not enabled in build */
+  #endif
+
   const char *filename = STATIC_TEST_PATH( "empty.szx" );
   libspectrum_byte *buffer = NULL;
   size_t filesize = 0;
@@ -764,6 +784,10 @@ test_30( void )
 static test_return_t
 test_71( void )
 {
+#ifndef HAVE_ZLIB_H
+  return TEST_SKIPPED; /* gzip not enabled in build */
+#endif
+
   const char *filename = STATIC_TEST_PATH( "random.szx" );
   libspectrum_byte *buffer = NULL;
   size_t filesize = 0;
@@ -1037,17 +1061,25 @@ main( int argc, char *argv[] )
       tests_done++;
       switch( test->test() ) {
       case TEST_PASS:
-	printf( "passed\n" );
-	pass++;
-	break;
+        /* Test executed completely and passed */
+	      printf( "passed\n" );
+	      pass++;
+	      break;
       case TEST_FAIL:
-	printf( "FAILED\n" );
-	fail++;
-	break;
+        /* Test executed completely but failed */
+	      printf( "FAILED\n" );
+	      fail++;
+	      break;
       case TEST_INCOMPLETE:
-	printf( "NOT COMPLETE\n" );
-	incomplete++;
-	break;
+        /* Error occurred while executing test */
+	      printf( "NOT COMPLETE\n" );
+	      incomplete++;
+	      break;
+      case TEST_SKIPPED:
+        /* Not possible to run this test (missing dependencies) */
+	      printf( "skipped\n" );
+	      tests_skipped++;
+	      break;
       }
     } else {
       tests_skipped++;

--- a/test/test.h
+++ b/test/test.h
@@ -9,6 +9,7 @@ typedef enum test_return_t {
   TEST_PASS,
   TEST_FAIL,
   TEST_INCOMPLETE,
+  TEST_SKIPPED,
 } test_return_t;
 
 typedef struct test_edge_sequence_t {


### PR DESCRIPTION
fix: Fixed running unittest checks which require gzip, but gzip was not enabled or available.

fix: Fixed running unittest checks which require gzip, but gzip was not enabled or available. In case of writing block, uncompressed size will be checked. In case of reading gzipped files, such tests will be skipped.

fix: Fixed core dump in test 39, when 85 (0x55) pages where to be saved, while memory was reserverd for 64.
refactor: Internal function for executing such test was modified to return error code in case more pages requested than actually reserved in memory.

unittest: Added support for returning TEST_SKIPPED as return value from test function.

See also https://sourceforge.net/p/arki55-fuse-mod/tickets/10/