### PR TITLE
build: Fix WII build of Libspectrum, it was not cross compiling.

### DIFF
--- a/.github/workflows/build_wii_sub.yml
+++ b/.github/workflows/build_wii_sub.yml
@@ -80,7 +80,7 @@ jobs:
           echo ""
 
           # Override path to allow cross-compiling
-          echo "$GITHUB_PATH:$DEVKITPPC/bin" >> $GITHUB_PATH
+          echo "$GITHUB_PATH:$DEVKITPPC/bin" >> "$GITHUB_PATH"
 
       - name: (2) Check out repository code
         uses: actions/checkout@v3
@@ -145,8 +145,8 @@ jobs:
       - name: (10) Install
         run: |
           # Override path to allow cross-compiling (again?)
-          echo "$GITHUB_PATH:$DEVKITPPC/bin" >> $GITHUB_PATH
-          echo "$PATH:$DEVKITPPC/bin" >> $PATH
+          echo "$GITHUB_PATH:$DEVKITPPC/bin" >> "$GITHUB_PATH"
+          echo "$PATH:$DEVKITPPC/bin" >> "$PATH"
           echo "Path(1) is: $GITHUB_PATH"
           echo "Path(2) is: $PATH"
 

--- a/.github/workflows/build_wii_sub.yml
+++ b/.github/workflows/build_wii_sub.yml
@@ -80,7 +80,7 @@ jobs:
           echo ""
 
           # Override path to allow cross-compiling
-          echo "$PATH:$DEVKITPPC/bin" >> $GITHUB_PATH
+          echo "$GITHUB_PATH:$DEVKITPPC/bin" >> $GITHUB_PATH
 
       - name: (2) Check out repository code
         uses: actions/checkout@v3

--- a/.github/workflows/build_wii_sub.yml
+++ b/.github/workflows/build_wii_sub.yml
@@ -79,6 +79,9 @@ jobs:
           dkp-pacman -Sl dkp-libs
           echo ""
 
+          # Override path to allow cross-compiling
+          echo "$PATH:$DEVKITPPC/bin" >> $GITHUB_PATH
+
       - name: (2) Check out repository code
         uses: actions/checkout@v3
         with:
@@ -125,6 +128,8 @@ jobs:
 
       - name: (8) Verify output from configure
         run: |
+          .github/scripts/in_config.sh "checking whether we are cross compiling... yes"
+          .github/scripts/in_config.sh "checking for powerpc-eabi-gcc... powerpc-eabi-gcc"
           .github/scripts/in_config.sh "libspectrum is ready to be compiled"
           .github/scripts/in_config.sh "zlib support: ${{ inputs.use_zlib && 'yes' || 'no' }}"
           .github/scripts/in_config.sh "bzip2 support: ${{ inputs.use_bzip2 && 'yes' || 'no' }}"

--- a/.github/workflows/build_wii_sub.yml
+++ b/.github/workflows/build_wii_sub.yml
@@ -144,10 +144,13 @@ jobs:
 
       - name: (10) Install
         run: |
+          # Override path to allow cross-compiling (again?)
+          echo "$GITHUB_PATH:$DEVKITPPC/bin" >> $GITHUB_PATH
+          echo "$PATH:$DEVKITPPC/bin" >> $PATH
+          echo "Path(1) is: $GITHUB_PATH"
+          echo "Path(2) is: $PATH"
+
           echo "Running make install .."
-          echo "Path is: $GITHUB_PATH"
-          whereis powerpc-eabi-ranlib
-          powerpc-eabi-ranlib
           make install
 
       - name: (11) Copy dependencies

--- a/.github/workflows/build_wii_sub.yml
+++ b/.github/workflows/build_wii_sub.yml
@@ -144,12 +144,8 @@ jobs:
 
       - name: (10) Install
         run: |
-          # Override path to allow cross-compiling (again?)
-          echo "$GITHUB_PATH:$DEVKITPPC/bin" >> "$GITHUB_PATH"
-          echo "$PATH:$DEVKITPPC/bin" >> "$PATH"
           echo "Path(1) is: $GITHUB_PATH"
           echo "Path(2) is: $PATH"
-
           echo "Running make install .."
           make install
 

--- a/.github/workflows/build_wii_sub.yml
+++ b/.github/workflows/build_wii_sub.yml
@@ -79,8 +79,8 @@ jobs:
           dkp-pacman -Sl dkp-libs
           echo ""
 
-          # Override path to allow cross-compiling
-          echo "$GITHUB_PATH:$DEVKITPPC/bin" >> "$GITHUB_PATH"
+          # Override path to allow cross-compiling (add to file)
+          echo "$DEVKITPPC/bin" >> $GITHUB_PATH
 
       - name: (2) Check out repository code
         uses: actions/checkout@v3
@@ -144,8 +144,6 @@ jobs:
 
       - name: (10) Install
         run: |
-          echo "Path(1) is: $GITHUB_PATH"
-          echo "Path(2) is: $PATH"
           echo "Running make install .."
           make install
 

--- a/.github/workflows/build_wii_sub.yml
+++ b/.github/workflows/build_wii_sub.yml
@@ -145,7 +145,10 @@ jobs:
       - name: (10) Install
         run: |
           echo "Running make install .."
-          sudo make install
+          echo "Path is: $GITHUB_PATH"
+          whereis powerpc-eabi-ranlib
+          powerpc-eabi-ranlib
+          make install
 
       - name: (11) Copy dependencies
         run: |


### PR DESCRIPTION
Fixing GitHub workflow for building Libspectrum for WII. It was not crosscompiling. Added check in step after configure to  make sure that cross compilint was activated. Path had to be overridden to prefer cross compile tools instead of their standard versions.

See more:
https://sourceforge.net/p/arki55-fuse-mod/tickets/11/