### PR TITLE
build: Fix WII build of Libspectrum, it was not cross compiling.  ==>  master

### DIFF
--- a/.github/workflows/build_wii_sub.yml
+++ b/.github/workflows/build_wii_sub.yml
@@ -79,6 +79,9 @@ jobs:
           dkp-pacman -Sl dkp-libs
           echo ""
 
+          # Override path to allow cross-compiling (add to file)
+          echo "$DEVKITPPC/bin" >> $GITHUB_PATH
+
       - name: (2) Check out repository code
         uses: actions/checkout@v3
         with:
@@ -125,6 +128,8 @@ jobs:
 
       - name: (8) Verify output from configure
         run: |
+          .github/scripts/in_config.sh "checking whether we are cross compiling... yes"
+          .github/scripts/in_config.sh "checking for powerpc-eabi-gcc... powerpc-eabi-gcc"
           .github/scripts/in_config.sh "libspectrum is ready to be compiled"
           .github/scripts/in_config.sh "zlib support: ${{ inputs.use_zlib && 'yes' || 'no' }}"
           .github/scripts/in_config.sh "bzip2 support: ${{ inputs.use_bzip2 && 'yes' || 'no' }}"
@@ -140,7 +145,7 @@ jobs:
       - name: (10) Install
         run: |
           echo "Running make install .."
-          sudo make install
+          make install
 
       - name: (11) Copy dependencies
         run: |


### PR DESCRIPTION
Fixing GitHub workflow for building Libspectrum for WII. It was not crosscompiling. Added check in step after configure to  make sure that cross compiling was activated. Path had to be overridden to prefer cross compile tools instead of their standard versions.

See more:
https://sourceforge.net/p/arki55-fuse-mod/tickets/11/